### PR TITLE
Fixed Type Casting error on vimeo 9 id videos

### DIFF
--- a/lib/src/model/vimeo_video_config.dart
+++ b/lib/src/model/vimeo_video_config.dart
@@ -511,7 +511,7 @@ class VimeoStream {
     this.fps,
   });
 
-  int? profile;
+  String? profile;
   String? quality;
   dynamic id;
   int? fps;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vimeo_video_player
 description: A Video Player that support videos from Vimeo platform in Flutter. This Package allow us to play any videos from Vimeo by using its Vimeo Video Id.
-version: 0.0.3
+version: 0.0.4
 homepage: https://github.com/Mindinventory/vimeo_video_player
 
 environment:


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/67022917/179508619-1a6490fc-8700-4eb8-a82b-d63388dc1c5e.png)
![image](https://user-images.githubusercontent.com/67022917/179508646-e19f3b94-4471-416e-8588-12953ba9b3ae.png)
![image](https://user-images.githubusercontent.com/67022917/179508662-ee5929c8-35d6-44e9-a70a-39f8a2890616.png)
There is problem with Type Casting. New vimeo videos has String Type **profile** property.
