### PR TITLE
Fix: Pressing back button while fullscreen causes red screen of death

### DIFF
--- a/lib/src/vimeo_player.dart
+++ b/lib/src/vimeo_player.dart
@@ -95,6 +95,7 @@ class _VimeoVideoPlayerState extends State<VimeoVideoPlayer> {
   @override
   void dispose() {
     /// disposing the controllers
+    _flickManager.flickControlManager?.exitFullscreen();
     _flickManager.dispose();
     _videoPlayerController.dispose();
     SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vimeo_video_player
 description: A Video Player that support videos from Vimeo platform in Flutter. This Package allow us to play any videos from Vimeo by using its Vimeo Video Id.
-version: 0.0.6
+version: 0.0.7
 repository: https://github.com/Mindinventory/vimeo_video_player
 issue_tracker: https://github.com/Mindinventory/vimeo_video_player/issues
 


### PR DESCRIPTION
Pressing the back button while playing a video in full-screen mode will result in Flutter's 'Red screen of death'.

The fix for this is by exiting full screen mode before you dispose of the video player.