### PR TITLE
Update flick_video_player to 0.8.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
 
   dio: ^5.4.1
-  flick_video_player: ^0.7.0
+  flick_video_player: ^0.8.0
   video_player: ^2.8.2
 
 dev_dependencies:


### PR DESCRIPTION
Since flick_video_player 0.7.0 doesn't work well with the new Flutter version and new versions of other dependencies (especially for the win32 part), flick_video_player should be bumped to 0.8.0. 

I tested the fork on my own project, all works with the bump.