### PR TITLE
Adds Class property to Enable Fullscreen on Play

### DIFF
--- a/lib/src/vimeo_player.dart
+++ b/lib/src/vimeo_player.dart
@@ -46,6 +46,12 @@ class VimeoVideoPlayer extends StatelessWidget {
   /// Default value: [true]
   final bool enableDNT;
 
+  /// Used to enable fullscreen mode when playing
+  /// When enabled, the player go full screen when play is hit
+  ///
+  /// Default value: [false]
+  final bool enableFullScreenOnPlay;
+
   /// Defines the background color of the InAppWebView
   ///
   /// Default Value: [Colors.black]
@@ -98,6 +104,7 @@ class VimeoVideoPlayer extends StatelessWidget {
     this.showByline = false,
     this.showControls = true,
     this.enableDNT = true,
+    this.enableFullScreenOnPlay = false,
     this.backgroundColor = Colors.black,
     this.onReady,
     this.onPlay,
@@ -198,7 +205,8 @@ class VimeoVideoPlayer extends StatelessWidget {
         '&title=$showTitle'
         '&byline=$showByline'
         '&controls=$showControls'
-        '&dnt=$enableDNT';
+        '&dnt=$enableDNT'
+        '&playsinline=${enableFullScreenOnPlay ? 0 : 1}';
   }
 
   /// Manage vimeo player events received from the WebView


### PR DESCRIPTION
With this change we to add a property to the class that enables/disabled the playsinline flag to the html.  The default state is off as to not breaking existing changes.  This effectively gives the ability to developers to make their videos go full screen on plan.  Because of this i felt naming the property "enableFullscreeenOnPlay" more descriptive than the actually  flag name "playsInline".  

Readings over playsinline flag.
https://help.vimeo.com/hc/en-us/articles/12425812053265-Inline-playback-on-mobile